### PR TITLE
Include tests in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,9 @@
-include examples/*.py
-include visvisResources/*
-include vvio/*.py
-include processing/*.py
-include vvmovie/*.py
+graft examples
+graft processing
+graft tests
+graft utils
+graft visvisResources
+graft vvio
+graft vvmovie
+
 include license.txt


### PR DESCRIPTION
This allows downstream packagers to make sure everything is setup up correctly.  

Also simplify `Manifest.in` file in general.